### PR TITLE
fix: Prevent Keydown event being triggered twice for CJK languages

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -73,6 +73,8 @@ export const TagsInput = ({
 
     if (text && (separators || defaultSeparators).includes(e.key)) {
       e.preventDefault();
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+
       if (beforeAddValidate && !beforeAddValidate(text, tags)) return;
 
       if (tags.includes(text)) {


### PR DESCRIPTION
# Problem

In Chrome-based browsers, entering Non-Latin-based language such as Chinese, Japanese and Korean (CJK) triggers Keydown event **2 times**. Hence, the LAST letter is added to the tag list as well.

![chrome](https://user-images.githubusercontent.com/27835019/235838811-48d3cbb4-007f-4a4a-8773-e6232adbc574.gif)

(chrome)

![safari](https://user-images.githubusercontent.com/27835019/235838835-0251881e-3c52-4f22-b19a-b5cd8d3b7152.gif)

(safari)

## Causes

The root cause of the problem has to do with Chrome, IME and Keydown Event. Typing CJK languages need the help of IME. When IME is used, Chrome triggers [Keydown event **********twice**********.](https://groups.google.com/g/mozilla.dev.platform/c/oZEz5JH9ZK8)

While each letter in an English word is simply an alphabet character, each letter in CJK is composed of 2 or more characters. Keydown event has a boolean property '**isComposing**’ to track if the user is composing a letter. 

When a user types in some CJK word, isComposing property returns **true** - since the last letter is still considered being 'in the composition process’. When pressing the 'separator' key, Chrome’s bug triggers Keydown event twice, firstly for the whole word and secondly for the last letter which still remains in the input box because it was considered being composed when the first Keydown event was triggered. This results in both the word and the last letter to be added the tag list.

For the record, for any alphabet character, ‘isComposing’ property always returns ‘false’ value. Hence, the fix won't affect other languages.

## Solution

Since alphabet characters always return falsy isComposing property, we only need to track if 'isComposing' is true. By doing so, the first Keydown event is ignored and ends composition process, and the second Keydown event correctly submits the whole word.

```tsx
const handleOnKeyUp = e => {
  ...
  if (text && (separators || defaultSeparators).includes(e.key)) {
    e.preventDefault();
    **if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;**
    ...
  
    }
  ...
}
  
```

## Reference

[https://groups.google.com/g/mozilla.dev.platform/c/oZEz5JH9ZK8](https://groups.google.com/g/mozilla.dev.platform/c/oZEz5JH9ZK8)

[https://github.com/vuejs/vue/issues/10277#issuecomment-873337252](https://github.com/vuejs/vue/issues/10277#issuecomment-873337252)

[https://core.trac.wordpress.org/ticket/45371](https://core.trac.wordpress.org/ticket/45371)

[https://stackoverflow.com/a/25509350](https://stackoverflow.com/a/25509350)