### PR TITLE
Add option to set separators by keyCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ export default Example;
 | `onKeyUp`           | input `onKeyUp` callback                                                        | `event`                                            |                 |
 | `onBlur`            | input `onBlur` callback                                                         | `event`                                            |                 |
 | `separators`         | when to add tag (i.e. `"Enter"`, `" "`)                                        | `string[]`                                         | `["Enter"]`     |
+| `separatorsByKeyCode` | when to add tag by keyCode (i.e. `13` for Enter key). When this option is set, `separators` will be ignored.                                      | `number[]`                                         | `[]`     |
 | `removers`          | Remove last tag if textbox empty and `Backspace` is pressed                     | `string[]`                                         | `["Backspace"]` |
 | `onExisting`        | if tag is already added then callback                                           | `(tag: string) => void`                            |                 |
 | `onRemoved`         | on tag removed callback                                                         | `(tag: string) => void`                            |                 |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ export interface TagsInputProps {
   onChange?: (tags: string[]) => void;
   onBlur?: any;
   separators?: string[];
+  separatorsByKeyCode?: number[];
   disableBackspaceRemove?: boolean;
   onExisting?: (tag: string) => void;
   onRemoved?: (tag: string) => void;
@@ -35,6 +36,7 @@ export const TagsInput = ({
   onChange,
   onBlur,
   separators,
+  separatorsByKeyCode,
   disableBackspaceRemove,
   onExisting,
   onRemoved,
@@ -70,17 +72,30 @@ export const TagsInput = ({
       e.target.value = isEditOnRemove ? `${tags.at(-1)} ` : "";
       setTags([...tags.slice(0, -1)]);
     }
+    if (separatorsByKeyCode && separatorsByKeyCode.length) {
+      if (text && (separatorsByKeyCode).includes(e.keyCode)) {
+        e.preventDefault();
+        if (beforeAddValidate && !beforeAddValidate(text, tags)) return;
 
-    if (text && (separators || defaultSeparators).includes(e.key)) {
-      e.preventDefault();
-      if (beforeAddValidate && !beforeAddValidate(text, tags)) return;
-
-      if (tags.includes(text)) {
-        onExisting && onExisting(text);
-        return;
+        if (tags.includes(text)) {
+          onExisting && onExisting(text);
+          return;
+        }
+        setTags([...tags, text]);
+        e.target.value = "";
       }
-      setTags([...tags, text]);
-      e.target.value = "";
+    } else {
+      if (text && (separators || defaultSeparators).includes(e.key)) {
+        e.preventDefault();
+        if (beforeAddValidate && !beforeAddValidate(text, tags)) return;
+
+        if (tags.includes(text)) {
+          onExisting && onExisting(text);
+          return;
+        }
+        setTags([...tags, text]);
+        e.target.value = "";
+      }
     }
   };
 


### PR DESCRIPTION
When input  multibytes language, some browser, Chrome, treat composition end event as Enter key pressed.
Fix the problem by adding new option to set separators by keyCode.  